### PR TITLE
feat: persist task order

### DIFF
--- a/client/src/components/Task/api.ts
+++ b/client/src/components/Task/api.ts
@@ -1,9 +1,13 @@
 import {instanceApi} from "../../constans";
-import {ITaskRequestBody} from "./taskSlice";
+import {ITask, ITaskRequestBody} from "./taskSlice";
 
 export const getAllTasks = async ()=>{
     return await instanceApi.get('tasks',{})
 }
 export const createTask = async (body:ITaskRequestBody) => {
     return await instanceApi.post('tasks', body)
+}
+
+export const editTask = async (body: Partial<ITask> & {id: number}) => {
+    return await instanceApi.patch('tasks', body)
 }

--- a/client/src/components/Task/taskSlice.ts
+++ b/client/src/components/Task/taskSlice.ts
@@ -16,6 +16,8 @@ export interface ITaskRequestBody {
     description: string;
     status:string
 
+    order?: number;
+
     executorId: number;
 }
 export interface ITask {
@@ -23,6 +25,7 @@ export interface ITask {
     name: string,
     description: string,
     status: string,
+    order: number,
     executor: {
         id: number,
         name: string,

--- a/client/src/components/TaskBoard/TaskBoard.tsx
+++ b/client/src/components/TaskBoard/TaskBoard.tsx
@@ -2,13 +2,21 @@ import React, { useState } from "react";
 import styles from './TaskBoard.module.css'
 import {ITask, selectTasks, updateTasks} from "../Task/taskSlice";
 import {useAppDispatch, useAppSelector} from "../../hooks/storeHooks";
+import {editTask} from "../Task/api";
 
 
 
 const TaskBoard: React.FC = () => {
-const dispatch=useAppDispatch()
-    const tasks=useAppSelector(selectTasks)
-    console.log(tasks);
+    const dispatch = useAppDispatch();
+    const tasks = useAppSelector(selectTasks);
+
+    const getSortedTasks = (status: string) =>
+        tasks
+            .filter(item => item.status === status)
+            .sort((a, b) => a.order - b.order);
+
+    const sourceTasks = getSortedTasks('Источник');
+    const goalTasks = getSortedTasks('Цель');
 
     const [draggedItem, setDraggedItem] = useState<ITask | null>(null);
 
@@ -16,18 +24,30 @@ const dispatch=useAppDispatch()
         setDraggedItem(item);
     };
 
-    const onDrop = (status:string) => {
-        if (draggedItem) {
-            const actualSourceItems=tasks.map((item:ITask)=>{
-                if(item.id===draggedItem.id){
-                    return {...item,status:status
-                    }
-                }
-                return item
-            })
-            dispatch(updateTasks(actualSourceItems))
-            setDraggedItem(null);
-        }
+    const onDropContainer = async (status: string) => {
+        if (!draggedItem) return;
+        const statusItems = tasks.filter((t: ITask) => t.status === status);
+        const maxOrder = statusItems.reduce((m, i) => Math.max(m, i.order), 0);
+        const updated = { ...draggedItem, status, order: maxOrder + 1 };
+        const updatedTasks = tasks.map((item: ITask) => item.id === draggedItem.id ? updated : item);
+        dispatch(updateTasks(updatedTasks));
+        await editTask({ id: updated.id, status: updated.status, order: updated.order });
+        setDraggedItem(null);
+    };
+
+    const onDropItem = async (target: ITask) => {
+        if (!draggedItem || target.id === draggedItem.id) return;
+        const replacements: Record<number, ITask> = {
+            [draggedItem.id]: { ...draggedItem, status: target.status, order: target.order },
+            [target.id]: { ...target, order: draggedItem.order }
+        };
+        const updatedTasks = tasks.map((item: ITask) => replacements[item.id] ?? item);
+        dispatch(updateTasks(updatedTasks));
+        await Promise.all([
+            editTask({ id: draggedItem.id, status: target.status, order: target.order }),
+            editTask({ id: target.id, order: draggedItem.order })
+        ]);
+        setDraggedItem(null);
     };
 
     const onDragOver = (event: React.DragEvent<HTMLDivElement>) => {
@@ -39,14 +59,16 @@ const dispatch=useAppDispatch()
             <div
                 className={styles.container}
                 onDragOver={onDragOver}
-                onDrop={()=>onDrop('Источник')}
+                onDrop={() => onDropContainer('Источник')}
             >
                 <h3>Источник</h3>
-                {tasks.filter(item=>item.status==='Источник').map((item) => (
+                {sourceTasks.map((item) => (
                     <div
                         key={item.id}
                         draggable
                         onDragStart={() => onDragStart(item)}
+                        onDrop={() => onDropItem(item)}
+                        onDragOver={onDragOver}
                         className={styles.item}
                     >
                         <p>{item.name}</p>
@@ -59,14 +81,16 @@ const dispatch=useAppDispatch()
             <div
                 className={styles.container}
                 onDragOver={onDragOver}
-                onDrop={()=>onDrop('Цель')}
+                onDrop={() => onDropContainer('Цель')}
             >
                 <h3>Цель</h3>
-                {tasks.filter(item=>item.status==='Цель').map((item) => (
+                {goalTasks.map((item) => (
                     <div
                         key={item.id}
                         draggable
                         onDragStart={() => onDragStart(item)}
+                        onDrop={() => onDropItem(item)}
+                        onDragOver={onDragOver}
                        className={styles.item}
                     >
                         <p>{item.name}</p>

--- a/server/data-source.ts
+++ b/server/data-source.ts
@@ -1,0 +1,17 @@
+import 'dotenv/config';
+import { DataSource } from 'typeorm';
+import { TasksEntity } from './src/tasks/tasks.entity';
+import { UsersEntity } from './src/users/users.entity';
+
+export const AppDataSource = new DataSource({
+    type: process.env.dialect as any,
+    host: process.env.POSTGRES_HOST,
+    port: Number(process.env.POSTGRES_PORT),
+    username: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DB,
+    entities: [TasksEntity, UsersEntity],
+    migrations: ['src/migrations/*.ts'],
+});
+
+export default AppDataSource;

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "migration:run": "typeorm-ts-node-commonjs migration:run -d data-source.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/server/src/configuration.ts
+++ b/server/src/configuration.ts
@@ -9,10 +9,14 @@ export const configuration = () => ({
         password: process.env.POSTGRES_PASSWORD,
         database: process.env.POSTGRES_DB,
         autoLoadEntities: true,
-        synchronize: true,
+        synchronize: false,
+        migrationsRun: true,
         logging: false,
         entities: [
             'dist/**/*.entity{.ts,.js}'
+        ],
+        migrations: [
+            'dist/migrations/*{.ts,.js}'
         ]
     }
 });

--- a/server/src/migrations/1721660000000-add-task-order.ts
+++ b/server/src/migrations/1721660000000-add-task-order.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddTaskOrder1721660000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn('tasks_entity', new TableColumn({
+            name: 'task_order',
+            type: 'int',
+            isNullable: false,
+            default: 0,
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('tasks_entity', 'task_order');
+    }
+}

--- a/server/src/tasks/tasks.dto.ts
+++ b/server/src/tasks/tasks.dto.ts
@@ -6,15 +6,25 @@ export class TasksDto{
     description: string;
     status:string
 
+    @IsOptional()
+    order?: number
+
     executorId: number;
 }
 
 export class TasksEditDto{
     id:number
-    name: string;
+    @IsOptional()
+    name?: string;
 
-    description: string;
-    status:string
+    @IsOptional()
+    description?: string;
+    @IsOptional()
+    status?:string
 
-    executorId: number;
+    @IsOptional()
+    order?: number
+
+    @IsOptional()
+    executorId?: number;
 }

--- a/server/src/tasks/tasks.entity.ts
+++ b/server/src/tasks/tasks.entity.ts
@@ -17,6 +17,9 @@ export class TasksEntity {
     @Column('text',{ nullable: false })
     status: string;
 
+    @Column({ type: 'int', name: 'task_order', default: 0 })
+    order: number;
+
     @ManyToOne(() => UsersEntity, (user) => user.tasks, { nullable: false })
     executor: UsersEntity;
 

--- a/server/src/tasks/tasks.service.ts
+++ b/server/src/tasks/tasks.service.ts
@@ -17,28 +17,31 @@ export class TasksService {
     ) {}
 
 
-    async createTask(dto:TasksDto):Promise<TasksEntity>{
-        const user =await this.userRepository.findOneBy({id:dto.executorId})
-        if(!user){
-            throw new Error('Пользовательне наеден')
+    async createTask(dto: TasksDto): Promise<TasksEntity> {
+        const user = await this.userRepository.findOneBy({ id: dto.executorId });
+        if (user) {
+            const task = this.taskRepository.create({
+                ...dto,
+                executor: user
+            });
+            return this.taskRepository.save(task);
         }
-        const task=this.taskRepository.create({
-            ...dto,
-            executor:user
-        })
-        return  this.taskRepository.save(task)
+        throw new Error('Пользователь не найден');
     }
-    async editTask (dto:TasksEditDto):Promise<TasksEntity>{
-        const task =await this.taskRepository.findOneBy({id:dto.id})
-        if (!task) {
-            throw new Error(`Задача не наедена`);
-        }
-        Object.assign(task, dto);
-        return  this.taskRepository.save(task);
 
+    async editTask(dto: TasksEditDto): Promise<TasksEntity> {
+        const task = await this.taskRepository.findOneBy({ id: dto.id });
+        if (task) {
+            Object.assign(task, dto);
+            return this.taskRepository.save(task);
+        }
+        throw new Error('Задача не найдена');
     }
     async getAllTasks():Promise<TasksEntity[]>{
-        return this.taskRepository.find({relations: ['executor'],})
+        return this.taskRepository.find({
+            relations: ['executor'],
+            order: { status: 'ASC', order: 'ASC' }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- add order field to tasks and return sorted tasks
- allow updating task order via API
- persist drag-and-drop order on task board
- precompute sorted task lists before rendering to simplify JSX
- remove nested conditionals and add migration infrastructure for task order column

## Testing
- `npm test --workspace server` *(fails: No tests found, exiting with code 1)*
- `npm test --workspace client` *(fails: Missing script: "test")*
- `npm run migration:run --workspace server` *(fails: Unable to open file: "/workspace/fullStackApp/server/data-source.ts". Wrong driver: "undefined" given)*

------
https://chatgpt.com/codex/tasks/task_e_689e5c7267a083308770e17b9728bcd2